### PR TITLE
Always disable colors for logrus

### DIFF
--- a/cmd/vsphere-janitor/main.go
+++ b/cmd/vsphere-janitor/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	librato "github.com/mihasya/go-metrics-librato"
 	metrics "github.com/rcrowley/go-metrics"
 	"github.com/travis-ci/vsphere-janitor"
@@ -50,6 +51,8 @@ func main() {
 
 func mainAction(c *cli.Context) error {
 	ctx := context.Background()
+
+	logrus.SetFormatter(&logrus.TextFormatter{DisableColors: true})
 
 	log.WithContext(ctx).Info("starting vsphere-janitor")
 	defer func() { log.WithContext(ctx).Info("stopping vsphere-janitor") }()


### PR DESCRIPTION
Without this, it'll default to a log format that includes color codes. I think it's supposed to remove that when not run in a terminal, but it detects our production environment as having a terminal, so it's easier to just disable it
completely.
