### PR TITLE
vsphere: fix incorrect PoweredOn conditional

### DIFF
--- a/vsphere/client.go
+++ b/vsphere/client.go
@@ -107,7 +107,7 @@ func (vm *VirtualMachine) BootTime() *time.Time {
 }
 
 func (vm *VirtualMachine) PoweredOn() bool {
-	return vm.mvm.Summary.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOn
+	return vm.mvm.Summary.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn
 }
 
 func (vm *VirtualMachine) PowerOff(ctx context.Context) error {


### PR DESCRIPTION
Previously it returned true when the VM was _not_ powered on, which is the opposite of what we want. This caused the janitor to try to destroy all VMs that were powered on (but luckily it thought they were powered off, so it tried to destroy them without powering them off first, causing vSphere to error and the VMs were left alone).
