### PR TITLE
main: print error if returned by janitor.Cleanup

### DIFF
--- a/cmd/vsphere-janitor/main.go
+++ b/cmd/vsphere-janitor/main.go
@@ -97,7 +97,10 @@ func mainAction(c *cli.Context) error {
 
 	for {
 		for _, path := range paths {
-			janitor.Cleanup(ctx, path)
+			err := janitor.Cleanup(ctx, path)
+			if err != nil {
+				log.WithContext(ctx).WithError(err).Error("error cleaning up")
+			}
 		}
 
 		if c.Bool("once") {


### PR DESCRIPTION
Right now it's possible for janitor to just print the "sleeping" with "duration" log message, sleep, and then repeat if janitor.Cleanup returns an error without logging it, so we should log the error so we can tell what's going on (probably an error listing the VMs).
