### PR TITLE
Add pprof HTTP server

### DIFF
--- a/cmd/vsphere-janitor/flags.go
+++ b/cmd/vsphere-janitor/flags.go
@@ -81,5 +81,10 @@ var (
 			Usage:  "Disable logging metrics to stderr",
 			EnvVar: "VSPHERE_JANITOR_SILENCE_METRICS,SILENCE_METRICS",
 		},
+		cli.StringFlag{
+			Name:   "pprof-port",
+			Usage:  "Port to set up net/http/pprof on",
+			EnvVar: "VSPHERE_JANITOR_PPROF_PORT,PPROF_PORT",
+		},
 	}
 )

--- a/cmd/vsphere-janitor/main.go
+++ b/cmd/vsphere-janitor/main.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"time"
 
+	_ "net/http/pprof"
+
 	"github.com/Sirupsen/logrus"
 	librato "github.com/mihasya/go-metrics-librato"
 	metrics "github.com/rcrowley/go-metrics"
@@ -56,6 +58,13 @@ func mainAction(c *cli.Context) error {
 
 	log.WithContext(ctx).Info("starting vsphere-janitor")
 	defer func() { log.WithContext(ctx).Info("stopping vsphere-janitor") }()
+
+	if c.String("pprof-port") != "" {
+		go func() {
+			log.WithContext(ctx).WithField("port", c.String("pprof-port")).Info("setting up pprof")
+			http.ListenAndServe("localhost:"+c.String("pprof-port"), nil)
+		}()
+	}
 
 	u, err := url.Parse(c.String("vsphere-url"))
 	if err != nil {

--- a/cmd/vsphere-janitor/main.go
+++ b/cmd/vsphere-janitor/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"time"


### PR DESCRIPTION
vsphere-janitor appears to be using quite a lot of CPU, hopefully we can profile it with this and figure out what's causing it to spend so much CPU time.