### PR TITLE
Detect stale powered off VMs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.7.1
+go: 1.8
 sudo: false
 install:
 - make prereqs

--- a/cmd/vsphere-janitor/flags.go
+++ b/cmd/vsphere-janitor/flags.go
@@ -39,6 +39,12 @@ var (
 			Usage:  "Max uptime cutoff",
 			EnvVar: "VSPHERE_JANITOR_CUTOFF,CUTOFF",
 		},
+		cli.DurationFlag{
+			Name:   "zero-uptime-cutoff",
+			Value:  5 * time.Minute,
+			Usage:  "Max 'zero uptime' cutoff",
+			EnvVar: "VSPHERE_JANITOR_ZERO_UPTIME_CUTOFF,ZERO_UPTIME_CUTOFF",
+		},
 		cli.IntFlag{
 			Name:   "c, concurrency",
 			Usage:  "Concurrent cleanup goroutine count",

--- a/cmd/vsphere-janitor/main.go
+++ b/cmd/vsphere-janitor/main.go
@@ -85,11 +85,11 @@ func mainAction(c *cli.Context) error {
 	}
 
 	janitor := vspherejanitor.NewJanitor(vSphereLister, &vspherejanitor.JanitorOpts{
-		Cutoff:         c.Duration("cutoff"),
-		SkipDestroy:    c.Bool("skip-destroy"),
-		Concurrency:    c.Int("concurrency"),
-		RatePerSecond:  c.Int("rate-per-second"),
-		SkipZeroUptime: c.BoolT("skip-zero-uptime"),
+		Cutoff:           c.Duration("cutoff"),
+		ZeroUptimeCutoff: c.Duration("zero-uptime-cutoff"),
+		SkipDestroy:      c.Bool("skip-destroy"),
+		Concurrency:      c.Int("concurrency"),
+		RatePerSecond:    c.Int("rate-per-second"),
 	})
 
 	if c.String("librato-email") != "" && c.String("librato-token") != "" && c.String("librato-source") != "" {
@@ -107,7 +107,7 @@ func mainAction(c *cli.Context) error {
 
 	for {
 		for _, path := range paths {
-			err := janitor.Cleanup(ctx, path)
+			err := janitor.Cleanup(ctx, path, time.Now())
 			if err != nil {
 				log.WithContext(ctx).WithError(err).Error("error cleaning up")
 			}

--- a/janitor_test.go
+++ b/janitor_test.go
@@ -23,12 +23,12 @@ var janitorTestCases []testCase = []testCase{
 	{
 		now: aTime,
 		config: &vspherejanitor.JanitorOpts{
-			Cutoff:         time.Hour,
-			SkipDestroy:    false,
-			Concurrency:    1,
-			RatePerSecond:  100,
-			SkipZeroUptime: true,
-			SkipNoBootTime: true,
+			Cutoff:           time.Hour,
+			ZeroUptimeCutoff: time.Minute,
+			SkipDestroy:      false,
+			Concurrency:      1,
+			RatePerSecond:    100,
+			SkipNoBootTime:   true,
 		},
 		vms: []*mock.VMData{
 			{
@@ -43,6 +43,12 @@ var janitorTestCases []testCase = []testCase{
 				BootTime:  timePointer(aTime.Add(-30 * time.Minute)),
 				PoweredOn: true,
 			},
+			{
+				Name:      "powered-off",
+				Uptime:    0,
+				BootTime:  nil,
+				PoweredOn: false,
+			},
 		},
 	},
 }
@@ -54,7 +60,7 @@ func TestJanitor(t *testing.T) {
 		})
 
 		janitor := vspherejanitor.NewJanitor(vmLister, c.config)
-		err := janitor.Cleanup(context.TODO(), "/")
+		err := janitor.Cleanup(context.TODO(), "/", c.now)
 		assertOk(t, "janitor.Cleanup(/)", err)
 
 		assertEqual(t, `PoweredOff("/", "old-powered-on")`, true, vmLister.PoweredOff("/", "old-powered-on"))

--- a/mock/virtual_machine.go
+++ b/mock/virtual_machine.go
@@ -108,6 +108,10 @@ func (vm *VirtualMachine) Name() string {
 	return vm.data.Name
 }
 
+func (vm *VirtualMachine) ID() string {
+	return vm.data.Name
+}
+
 func (vm *VirtualMachine) Uptime() time.Duration {
 	return vm.data.Uptime
 }

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -11,6 +11,7 @@ type VMLister interface {
 
 type VirtualMachine interface {
 	Name() string
+	ID() string
 	Uptime() time.Duration
 	BootTime() *time.Time
 	PoweredOn() bool

--- a/vsphere/client.go
+++ b/vsphere/client.go
@@ -100,6 +100,14 @@ func (vm *VirtualMachine) Name() string {
 	return vm.mvm.Config.Name
 }
 
+func (vm *VirtualMachine) ID() string {
+	if vm.mvm.Config == nil {
+		return ""
+	}
+
+	return vm.mvm.Config.Uuid
+}
+
 func (vm *VirtualMachine) Uptime() time.Duration {
 	return time.Duration(vm.mvm.Summary.QuickStats.UptimeSeconds) * time.Second
 }


### PR DESCRIPTION
This PR adds some internal state to keep track of when it first saw a VM with zero uptime, in order to clean them up if they've stuck along for longer than expected (normally a VM would stay in this state for a few seconds, sometimes up to a minute or two while the VM is being powered on).

This isn't tested yet, I'm not 100% sure how to best write the tests for this yet.