### PR TITLE
Shut down ticker used in cleanup loop

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2017 Travis CI GmbH
+Copyright © 2018 Travis CI GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
time.Tick leaks tickers when called in a loop, causing a buildup of CPU usage for timers that are no longer being used:

> Tick is a convenience wrapper for NewTicker providing access to the ticking channel only. While Tick is useful for clients that have no need to shut down the Ticker, be aware that without a way to shut it down the underlying Ticker cannot be recovered by the garbage collector; it "leaks". Unlike NewTicker, Tick will return nil if d <= 0.

Using the [perf](http://www.brendangregg.com/blog/2014-06-22/perf-cpu-sample.html) tool, I found that vsphere-janitor was spending most of its CPU time in `runtime.siftdownTimer`, which led me [here](https://forum.golangbridge.org/t/runtime-siftdowntimer-consuming-60-of-the-cpu/3773/2). I definitely think this is the reason that vsphere-janitor's CPU usage gets steadily worse over time.